### PR TITLE
Add Debug, Copy and Clone derive to many enums

### DIFF
--- a/src/linux/genetlink/mod.rs
+++ b/src/linux/genetlink/mod.rs
@@ -32,6 +32,7 @@ pub const GENL_START_ALLOC: u16		= netlink::NLMSG_MIN_TYPE + 3;
 
 // Controller
 #[allow(non_camel_case_types)]
+#[derive(Debug, Copy, Clone)]
 #[repr(u8)]
 pub enum CtrlCmd {
     UNSPEC		= 0,
@@ -60,6 +61,7 @@ pub const __CTRL_CMD_MAX: u8		= CtrlCmd::_MAX as u8;
 pub const CTRL_CMD_MAX: u8		= __CTRL_CMD_MAX - 1;
 
 #[allow(non_camel_case_types)]
+#[derive(Debug, Copy, Clone)]
 #[repr(u16)]
 pub enum CtrlAttr {
     UNSPEC		= 0,
@@ -83,6 +85,7 @@ pub const CTRL_ATTR_MCAST_GROUPS: u16	= CtrlAttr::MCAST_GROUPS as u16;
 pub const __CTRL_ATTR_MAX: u16		= 8u16; // CtrlAttr::_MAX as u16;
 pub const CTRL_ATTR_MAX: u16		= __CTRL_ATTR_MAX - 1;
 
+#[derive(Debug, Copy, Clone)]
 #[repr(u16)]
 pub enum CtrlAttrOp {
     UNSPEC	= 0,
@@ -96,6 +99,7 @@ pub const CTRL_ATTR_OP_FLAGS: u16	= CtrlAttrOp::FLAGS as u16;
 pub const __CTRL_ATTR_OP_MAX: u16	= 3u16; // CtrlAttrOp::_MAX as u16;
 pub const CTRL_ATTR_OP_MAX: u16		= __CTRL_ATTR_OP_MAX - 1;
 
+#[derive(Debug, Copy, Clone)]
 #[repr(u16)]
 pub enum CtrlAttrMcastGrp {
     UNSPEC	= 0,

--- a/src/linux/if_addr/mod.rs
+++ b/src/linux/if_addr/mod.rs
@@ -20,6 +20,7 @@ pub struct Ifaddrmsg {
 //
 // IFA_FLAGS is a u32 attribute that extends the u8 field ifa_flags.
 // If present, the value from struct ifaddrmsg will be ignored.
+#[derive(Debug, Copy, Clone)]
 #[repr(u16)]
 pub enum IFA {
     UNSPEC	= 0,

--- a/src/linux/netfilter/mod.rs
+++ b/src/linux/netfilter/mod.rs
@@ -6,6 +6,7 @@ pub mod nf_conntrack_common;
 pub mod nf_conntrack_tcp;
 
 // Responses from hook functions.
+#[derive(Debug, Copy, Clone)]
 #[repr(u32)] // ???
 pub enum Verdict {
     DROP	= 0,
@@ -57,6 +58,7 @@ pub const NF_VERDICT_BITS: u8	=  16;
 // #endif
 
 #[allow(non_camel_case_types)]
+#[derive(Debug, Copy, Clone)]
 #[repr(u8)]
 pub enum InetHooks {
     // bitop? or u32
@@ -82,6 +84,7 @@ pub enum DevHooks {
 pub const NF_NETDEV_INGRESS: u32	= DevHooks::INGRESS as u32;
 pub const NF_NETDEV_NUMHOOKS: u32	= DevHooks::NUMHOOKS as u32;
 
+#[derive(Debug, Copy, Clone)]
 #[repr(u8)]
 pub enum Proto {
     UNSPEC	=  0,


### PR DESCRIPTION
This would make the enums easier to use. Now they can be cast to integers without having to consume the enum. Without this one could not even clone the enum, so if I wanted to use `Proto` in two places I had to instantiate two different instances.

This does not add it to *all* enums. I basically just needed it on `Proto` for now and added it to a few more enums that were just C style enums.